### PR TITLE
Add swift-package support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MaterialTapTargetPrompt-iOS",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "MaterialTapTargetPrompt-iOS",
+            targets: ["MaterialTapTargetPrompt"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "MaterialTapTargetPrompt",
+            dependencies: [],
+            path: "MaterialTapTargetPrompt/MaterialTapTargetPrompt/Classes"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ tapTargetPrompt.textPostion = .bottomRight
 
 ## Installation
 
+### CocoaPods
+
 MaterialTapTargetPrompt-iOS is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
@@ -39,11 +41,30 @@ it, simply add the following line to your Podfile:
 pod 'MaterialTapTargetPrompt-iOS'
 ```
 
+### Carthage
+
 Or you can use [Carthage](https://github.com/Carthage/Carthage).
 
 ```
 github "Abedalkareem/MaterialTapTargetPrompt-iOS"
 ```
+
+### Swift Package Manager
+
+You can use also [Swift Package Manager](https://developer.apple.com/documentation/xcode/swift-packages):
+
+1. Open your project in Xcode
+2. Click "File" -> "Add Packages..."
+3. Paste the following URL: https://github.com/gallinaettore/MaterialTapTargetPrompt-iOS
+
+
+You can specify the dependency in `Package.swift` by adding this:
+
+```swift
+.package(url: "https://github.com/gallinaettore/MaterialTapTargetPrompt-iOS.git", .upToNextMajor(from: "1.0.6"))
+```
+
+
 
 ## Support me 🚀  
 


### PR DESCRIPTION
I've added support for the new swift-package so you can install the library via CocoaPods, Carthage and SPM.

When you pull, remember to update the link in the README.md file https://github.com/gallinaettore/MaterialTapTargetPrompt-iOS with https://github.com/Abedalkareem/MaterialTapTargetPrompt-iOS